### PR TITLE
fix(typos): Update example

### DIFF
--- a/examples/formatter-typos.toml
+++ b/examples/formatter-typos.toml
@@ -3,4 +3,4 @@
 command = "typos"
 excludes = []
 includes = ["*"]
-options = ["--write-changes"]
+options = ["--write-changes", "--force-exclude"]


### PR DESCRIPTION
This fixes the failure from <https://buildbot.numtide.com/#/builders/16/builds/403> that occurred as part of <https://github.com/numtide/treefmt-nix/pull/394>:

```
error: build of '/nix/store/yk55kcp0l13q9v1m3d8698aijm71ljwi-test-examples.drv' on 'ssh-ng://nix-remote-builder@bld3.numtide.com' failed: builder for '/nix/store/yk55kcp0l13q9v1m3d8698aijm71ljwi-test-examples.drv' failed with exit code 1;
last 7 log lines:
> diff -r /nix/store/wvsgycqi2js9q9s7ih5lmjki17zjxhjq-examples/formatter-typos.toml /nix/store/7l3i5xwdqdizgn6nvm0vh2yjai6ivx2w-examples/formatter-typos.toml
> 6c6
> < options = ["--write-changes"]
> ---
> > options = ["--write-changes", "--force-exclude"]
> The generated ./examples folder is out of sync
> Run ./examples.sh to fix the issue
```